### PR TITLE
Fixed typing problem in Samsung devices with a Bluetooth keyboard.

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -936,7 +936,13 @@ class RawEditorState extends EditorState
   }
 
   void _didChangeTextEditingValue() {
-    requestKeyboard();
+    // For users with Samsung devices with a Bluetooth keyboard,
+    // the soft keyboard will slide down when you type the first letter.
+    // Then, the soft keyboard remains down, allowing you to type additionally.
+    //
+    // When yoy call requestKeyboard() here,
+    // the problem is that the keyboard goes up and down every time you type.
+    // requestKeyboard();
 
     _showCaretOnScreen();
     updateRemoteValueIfNeeded();


### PR DESCRIPTION
![IMB_effVL7](https://user-images.githubusercontent.com/70277412/122688174-b7a48e00-d255-11eb-8f50-f2775bb3e91c.gif)

For users with Samsung devices with a Bluetooth keyboard, the soft keyboard will slide down when you type the first letter.  
Then, the soft keyboard remains down, allowing you to type additionally. 
The gif above is a typing screen under normal circumstances.

Below is a gif of typing in an editor using zefyrka.
As you can see, the soft keyboard is down and up each time when I type something.
I'm not sure if this is an issue specific to Samsung devices.
Anyway, this happens to my Samsung phone, and users who use my app have also reported the same phenomenon.

![IMB_ZAN8Mq](https://user-images.githubusercontent.com/70277412/122688108-54b2f700-d255-11eb-9fda-3a79848b48e3.gif)


My device is Samsung Galaxy S20 5G and the problem does not occur on iPhone.
