### PR TITLE
Fix #18: lack of `enableSuggestions` option

### DIFF
--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -126,6 +126,9 @@ class ZefyrEditor extends StatefulWidget {
   /// the text field from the clipboard.
   final bool enableInteractiveSelection;
 
+  /// Whether to enable auto-suggestions in the system keyboard (where applicable).
+  final bool enableSuggestions;
+
   /// The minimum height to be occupied by this editor.
   ///
   /// This only has effect if [scrollable] is set to `true` and [expands] is
@@ -209,6 +212,7 @@ class ZefyrEditor extends StatefulWidget {
     this.showCursor = true,
     this.readOnly = false,
     this.enableInteractiveSelection = true,
+    this.enableSuggestions = false,
     this.minHeight,
     this.maxHeight,
     this.scrollAreaMinHeight,
@@ -315,6 +319,7 @@ class _ZefyrEditorState extends State<ZefyrEditor>
       showCursor: widget.showCursor,
       readOnly: widget.readOnly,
       enableInteractiveSelection: widget.enableInteractiveSelection,
+      enableSuggestions: widget.enableSuggestions,
       minHeight: widget.minHeight,
       maxHeight: widget.maxHeight,
       scrollAreaMinHeight: widget.scrollAreaMinHeight,

--- a/lib/src/widgets/editor.dart
+++ b/lib/src/widgets/editor.dart
@@ -503,6 +503,7 @@ class RawEditor extends StatefulWidget {
       paste: true,
       selectAll: true,
     ),
+    this.enableSuggestions = true,
     this.cursorStyle,
     this.showSelectionHandles = false,
     this.selectionControls,
@@ -593,6 +594,9 @@ class RawEditor extends StatefulWidget {
   ///
   ///  * [TextCapitalization], for a description of each capitalization behavior.
   final TextCapitalization textCapitalization;
+
+  /// Whether to enable text suggestions in the keyboard when typing.
+  final bool enableSuggestions;
 
   /// The maximum height this editor can have.
   ///

--- a/lib/src/widgets/editor_input_client_mixin.dart
+++ b/lib/src/widgets/editor_input_client_mixin.dart
@@ -60,7 +60,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
           inputType: TextInputType.multiline,
           readOnly: widget.readOnly,
           obscureText: false,
-          autocorrect: false,
+          autocorrect: widget.enableSuggestions,
           inputAction: TextInputAction.newline,
           keyboardAppearance: widget.keyboardAppearance,
           textCapitalization: widget.textCapitalization,


### PR DESCRIPTION
Fixes #18 . 

I added a new option `enableSuggestions`, named similarly to flutter's `TextField`. It defaults to `false`, which is the current setup in `v1.0.5`, so this change does not break anything for existing users, but just offers them another option.

Thanks to #18 author @tony-soft for identifying where the fix should be.