### PR TITLE
Allow shortcut handling

### DIFF
--- a/lib/src/services/keyboard.dart
+++ b/lib/src/services/keyboard.dart
@@ -96,7 +96,7 @@ class KeyboardListener {
       // If the most recently pressed key isn't a non-modifier key, or more than
       // one non-modifier key is down, or keys other than the ones we're interested in
       // are pressed, just ignore the keypress.
-      return KeyEventResult.skipRemainingHandlers;
+      return KeyEventResult.ignored;
     }
 
     final bool isWordModifierPressed =

--- a/lib/src/services/keyboard.dart
+++ b/lib/src/services/keyboard.dart
@@ -95,7 +95,8 @@ class KeyboardListener {
         keysPressed.difference(_interestingKeys).isNotEmpty) {
       // If the most recently pressed key isn't a non-modifier key, or more than
       // one non-modifier key is down, or keys other than the ones we're interested in
-      // are pressed, just ignore the keypress.
+      // are pressed, ignore it here and let it propagate to other key event handlers
+      // (so an app-wide keyboard shortcut can be handled appropriately, for example).
       return KeyEventResult.ignored;
     }
 


### PR DESCRIPTION
This is a one-line change (plus updated comment) that allows the consuming flutter app to handle keyboard shortcuts as intended while the focus is on the text editor. If the particular key combination is not handled by zefyrka, it propagates to other keyboard handlers and lets them handle it as desired.

For example, in my macOS desktop flutter app, I have keyboard shortcuts (which are uniform for every screen of the app) where cmd+[ is "back" and cmd+] is "forward". This works elsewhere but does not work while the zefyrka editor is active because the zefyrka code was `KeyEventResult.skipRemainingHandlers` when it should be `KeyEventResult.ignored`. In both cases, the key event will be ignored by zefyrka if it's not an event zefyrka is listening to, but with this change it can now be properly intercepted outside of zefyrka if desired.