### PR TITLE
fixes null check error on _textInputConnection

### DIFF
--- a/lib/src/widgets/editor_input_client_mixin.dart
+++ b/lib/src/widgets/editor_input_client_mixin.dart
@@ -225,7 +225,10 @@ mixin RawEditorStateTextInputClientMixin on EditorState
       SchedulerBinding.instance!.addPostFrameCallback((Duration _) {
         final size = renderEditor.size;
         final transform = renderEditor.getTransformTo(null);
-        _textInputConnection!.setEditableSizeAndTransform(size, transform);
+        if (hasConnection) {
+          // causes error if connection is lost before post-frame callback executes
+          _textInputConnection!.setEditableSizeAndTransform(size, transform);
+        }
       });
     }
   }


### PR DESCRIPTION
This fixes an error where `_textInputConnection!` was assumed non-null in `RawEditorStateTextInputClientMixin._updateSizeAndTransform`, but was producing an error because it in fact was null.

![image](https://user-images.githubusercontent.com/31083702/156934628-df84ca33-f476-4d0d-af6e-3a57513a15c3.png)

This seems to be because even though it checks `hasConnection` at the beginning of `_updateSizeAndTransform` function, before the post-frame callback actually executes the connection is lost and thus `_textInputConnection` is no longer guaranteed to be non-null when the ! is used. I think this is happening because in my own app where zefyrka is being used, when you navigate back tot the zefyrka page from somewhere else it is doing additional things using post-frame callbacks that take the focus off of the zefyrka editor. I'm not completelly sure what the exact chain of events is, but adding this additional check, although somewhat redundant, prevents the error from happening and does not have any side effects that I can see.